### PR TITLE
Avoid NPE

### DIFF
--- a/src/main/java/hudson/plugins/buildblocker/BlockingJobsMonitor.java
+++ b/src/main/java/hudson/plugins/buildblocker/BlockingJobsMonitor.java
@@ -79,8 +79,8 @@ public class BlockingJobsMonitor {
             executors.addAll(computer.getOneOffExecutors());
 
             for (Executor executor : executors) {
-                if(executor.isBusy()) {
-                    Queue.Executable currentExecutable = executor.getCurrentExecutable();
+                Queue.Executable currentExecutable = executor.getCurrentExecutable();
+                if(currentExecutable!=null) {
 
                     SubTask subTask = currentExecutable.getParent();
                     Queue.Task task = subTask.getOwnerTask();


### PR DESCRIPTION
isBusy now covers the case where there is a workUnit but no executable. So if a job has been assigned but not started, you will start to get NPEs which will prevent anything from going anywhere.

Better to just check the current executable... or perhaps better yet the current work unit as you may be leaving a gap