### PR TITLE
[FIXED JENKINS-29924] Items with non-AbstractProjects tasks block the build queue

### DIFF
--- a/src/main/java/hudson/plugins/buildblocker/BuildBlockerQueueTaskDispatcher.java
+++ b/src/main/java/hudson/plugins/buildblocker/BuildBlockerQueueTaskDispatcher.java
@@ -202,8 +202,8 @@ public class BuildBlockerQueueTaskDispatcher extends QueueTaskDispatcher {
         if (!(item.task instanceof Job)) {
             return null;
         }
-        Job job = (Job) item.task;
+        Job<?,?> job = (Job<?,?>) item.task;
 
-        return (BuildBlockerProperty) job.getProperty(BuildBlockerProperty.class);
+        return job.getProperty(BuildBlockerProperty.class);
     }
 }

--- a/src/main/java/hudson/plugins/buildblocker/BuildBlockerQueueTaskDispatcher.java
+++ b/src/main/java/hudson/plugins/buildblocker/BuildBlockerQueueTaskDispatcher.java
@@ -105,11 +105,13 @@ public class BuildBlockerQueueTaskDispatcher extends QueueTaskDispatcher {
 
     @Override
     public CauseOfBlockage canTake(Node node, Queue.BuildableItem item) {
-        BuildBlockerProperty property = getBuildBlockerProperty(item);
-        if (property != null && property.isUseBuildBlocker()) {
-            CauseOfBlockage causeOfBlockage = checkForBlock(node, item, property);
-            if (causeOfBlockage != null) {
-                return causeOfBlockage;
+        if (item.task instanceof AbstractProject) {
+            BuildBlockerProperty property = getBuildBlockerProperty(item);
+            if (property != null && property.isUseBuildBlocker()) {
+                CauseOfBlockage causeOfBlockage = checkForBlock(node, item, property);
+                if (causeOfBlockage != null) {
+                    return causeOfBlockage;
+                }
             }
         }
         return super.canTake(node, item);


### PR DESCRIPTION
[JENKINS-29924](https://issues.jenkins-ci.org/browse/JENKINS-29924)

When an item which doesn't have an `AbstractProject` task stay in the queue blocks the build queue. This happens specifically with CloudBees proprietary plugin 
`long-running-builds`. However, it is in my opinion a bug.

It might be perfect not to use `Abstractproject` and instead `Job` so Workflow plugin is integrated. I might work on this, but for the moment my intention is just to fix this bug more than integrate with Workflow.

```
2015-08-08 13:50:48.211+0200 [id=62]    SEVERE  hudson.triggers.SafeTimerTask#run: Timer task hudson.model.Queue$MaintainTask@423e2af8 failed
java.lang.ClassCastException: com.cloudbees.jenkins.plugins.longrunning.BackgroundTask cannot be cast to hudson.model.AbstractProject
    at hudson.plugins.buildblocker.BuildBlockerQueueTaskDispatcher.getBuildBlockerProperty(BuildBlockerQueueTaskDispatcher.java:199)
    at hudson.plugins.buildblocker.BuildBlockerQueueTaskDispatcher.canTake(BuildBlockerQueueTaskDispatcher.java:108)
    at hudson.model.Queue$JobOffer.canTake(Queue.java:281)
    at hudson.model.Queue.maintain(Queue.java:1049)
    at hudson.model.Queue$MaintainTask.doRun(Queue.java:2033)
    at hudson.triggers.SafeTimerTask.run(SafeTimerTask.java:54)
    at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:471)
    at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:304)
    at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:178)
    at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
    at java.lang.Thread.run(Thread.java:745)
```

@reviewbybees