### PR TITLE
[FIXED JENKINS-29924] Transform AbstractProject into Job for Workflow compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.466</version>
+        <version>1.580.1</version>
     </parent>
 
     <artifactId>build-blocker-plugin</artifactId>
@@ -137,6 +137,29 @@
             <groupId>org.powermock</groupId>
             <artifactId>powermock-module-junit4</artifactId>
             <version>1.5.6</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>matrix-project</artifactId>
+            <version>1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-job</artifactId>
+            <version>1.4</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-cps</artifactId>
+            <version>1.4</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-aggregator</artifactId>
+            <version>1.4</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/hudson/plugins/buildblocker/BlockingJobsMonitor.java
+++ b/src/main/java/hudson/plugins/buildblocker/BlockingJobsMonitor.java
@@ -24,14 +24,12 @@
 
 package hudson.plugins.buildblocker;
 
-import com.infradna.tool.bridge_method_injector.WithBridgeMethods;
 import hudson.matrix.MatrixConfiguration;
 import hudson.model.Computer;
 import hudson.model.Executor;
 import hudson.model.Job;
 import hudson.model.Node;
 import hudson.model.Queue;
-import hudson.model.queue.SubTask;
 import jenkins.model.Jenkins;
 import org.apache.commons.lang.StringUtils;
 
@@ -71,7 +69,6 @@ public class BlockingJobsMonitor {
         }
     }
 
-    @WithBridgeMethods(value=SubTask.class)
     public Job checkForBuildableQueueEntries(Queue.Item item) {
         List<Queue.BuildableItem> buildableItems = Jenkins.getInstance().getQueue().getBuildableItems();
 
@@ -83,7 +80,6 @@ public class BlockingJobsMonitor {
         return null;
     }
 
-    @WithBridgeMethods(value=SubTask.class)
     public Job checkForQueueEntries(Queue.Item item) {
         List<Queue.Item> buildableItems = asList(Jenkins.getInstance().getQueue().getItems());
 
@@ -95,7 +91,6 @@ public class BlockingJobsMonitor {
         return null;
     }
 
-    @WithBridgeMethods(value=SubTask.class)
     public Job checkNodeForBuildableQueueEntries(Queue.Item item, Node node) {
         List<? extends Queue.Item> buildableItems = Jenkins.getInstance().getQueue().getBuildableItems(node.toComputer());
 
@@ -107,7 +102,6 @@ public class BlockingJobsMonitor {
         return null;
     }
 
-    @WithBridgeMethods(value=SubTask.class)
     public Job checkNodeForQueueEntries(Queue.Item item, Node node) {
         List<Queue.Item> buildableItemsOnNode = new ArrayList<Queue.Item>();
         for (Queue.Item buildableItem : Jenkins.getInstance().getQueue().getItems()) {
@@ -125,7 +119,6 @@ public class BlockingJobsMonitor {
         return null;
     }
 
-    @WithBridgeMethods(value=SubTask.class)
     public Job checkAllNodesForRunningBuilds() {
         Computer[] computers = Jenkins.getInstance().getComputers();
 
@@ -138,7 +131,6 @@ public class BlockingJobsMonitor {
         return null;
     }
 
-    @WithBridgeMethods(value=SubTask.class)
     private Job checkComputerForRunningBuilds(Computer computer) {
         List<Executor> executors = computer.getExecutors();
 
@@ -154,7 +146,6 @@ public class BlockingJobsMonitor {
         return null;
     }
 
-    @WithBridgeMethods(value=SubTask.class)
     public Job checkNodeForRunningBuilds(Node node) {
         if (node == null) {
             return null;
@@ -162,14 +153,15 @@ public class BlockingJobsMonitor {
         return checkComputerForRunningBuilds(node.toComputer());
     }
 
-    @WithBridgeMethods(value=SubTask.class)
     private Job checkForPlannedBuilds(Queue.Item item, List<? extends Queue.Item> buildableItems) {
         for (Queue.Item buildableItem : buildableItems) {
             if (item != buildableItem) {
                 for (String blockingJob : this.blockingJobs) {
-                    Job project = (Job) buildableItem.task;
-                    if (project.getFullName().matches(blockingJob)) {
-                        return project;
+                    if (buildableItem.task instanceof Job) {
+                        Job project = (Job) buildableItem.task;
+                        if (project.getFullName().matches(blockingJob)) {
+                            return project;
+                        }
                     }
                 }
             }
@@ -177,7 +169,6 @@ public class BlockingJobsMonitor {
         return null;
     }
 
-    @WithBridgeMethods(value=SubTask.class)
     private Job checkForRunningBuilds(Executor executor) {
         if (executor.isBusy()) {
             Queue.Task task = executor.getCurrentWorkUnit().work.getOwnerTask();

--- a/src/main/java/hudson/plugins/buildblocker/BlockingJobsMonitor.java
+++ b/src/main/java/hudson/plugins/buildblocker/BlockingJobsMonitor.java
@@ -24,12 +24,14 @@
 
 package hudson.plugins.buildblocker;
 
+import com.infradna.tool.bridge_method_injector.WithBridgeMethods;
 import hudson.matrix.MatrixConfiguration;
 import hudson.model.Computer;
 import hudson.model.Executor;
 import hudson.model.Job;
 import hudson.model.Node;
 import hudson.model.Queue;
+import hudson.model.queue.SubTask;
 import jenkins.model.Jenkins;
 import org.apache.commons.lang.StringUtils;
 
@@ -69,6 +71,7 @@ public class BlockingJobsMonitor {
         }
     }
 
+    @WithBridgeMethods(value=SubTask.class)
     public Job checkForBuildableQueueEntries(Queue.Item item) {
         List<Queue.BuildableItem> buildableItems = Jenkins.getInstance().getQueue().getBuildableItems();
 
@@ -80,6 +83,7 @@ public class BlockingJobsMonitor {
         return null;
     }
 
+    @WithBridgeMethods(value=SubTask.class)
     public Job checkForQueueEntries(Queue.Item item) {
         List<Queue.Item> buildableItems = asList(Jenkins.getInstance().getQueue().getItems());
 
@@ -91,6 +95,7 @@ public class BlockingJobsMonitor {
         return null;
     }
 
+    @WithBridgeMethods(value=SubTask.class)
     public Job checkNodeForBuildableQueueEntries(Queue.Item item, Node node) {
         List<? extends Queue.Item> buildableItems = Jenkins.getInstance().getQueue().getBuildableItems(node.toComputer());
 
@@ -102,6 +107,7 @@ public class BlockingJobsMonitor {
         return null;
     }
 
+    @WithBridgeMethods(value=SubTask.class)
     public Job checkNodeForQueueEntries(Queue.Item item, Node node) {
         List<Queue.Item> buildableItemsOnNode = new ArrayList<Queue.Item>();
         for (Queue.Item buildableItem : Jenkins.getInstance().getQueue().getItems()) {
@@ -119,6 +125,7 @@ public class BlockingJobsMonitor {
         return null;
     }
 
+    @WithBridgeMethods(value=SubTask.class)
     public Job checkAllNodesForRunningBuilds() {
         Computer[] computers = Jenkins.getInstance().getComputers();
 
@@ -131,6 +138,7 @@ public class BlockingJobsMonitor {
         return null;
     }
 
+    @WithBridgeMethods(value=SubTask.class)
     private Job checkComputerForRunningBuilds(Computer computer) {
         List<Executor> executors = computer.getExecutors();
 
@@ -146,6 +154,7 @@ public class BlockingJobsMonitor {
         return null;
     }
 
+    @WithBridgeMethods(value=SubTask.class)
     public Job checkNodeForRunningBuilds(Node node) {
         if (node == null) {
             return null;
@@ -153,6 +162,7 @@ public class BlockingJobsMonitor {
         return checkComputerForRunningBuilds(node.toComputer());
     }
 
+    @WithBridgeMethods(value=SubTask.class)
     private Job checkForPlannedBuilds(Queue.Item item, List<? extends Queue.Item> buildableItems) {
         for (Queue.Item buildableItem : buildableItems) {
             if (item != buildableItem) {
@@ -167,6 +177,7 @@ public class BlockingJobsMonitor {
         return null;
     }
 
+    @WithBridgeMethods(value=SubTask.class)
     private Job checkForRunningBuilds(Executor executor) {
         if (executor.isBusy()) {
             Queue.Task task = executor.getCurrentWorkUnit().work.getOwnerTask();
@@ -183,7 +194,7 @@ public class BlockingJobsMonitor {
                             return job;
                         }
                     } catch (java.util.regex.PatternSyntaxException pse) {
-                        return null;
+                        continue;
                     }
                 }
             }

--- a/src/main/java/hudson/plugins/buildblocker/BuildBlockerQueueTaskDispatcher.java
+++ b/src/main/java/hudson/plugins/buildblocker/BuildBlockerQueueTaskDispatcher.java
@@ -26,13 +26,11 @@ package hudson.plugins.buildblocker;
 
 import hudson.Extension;
 import hudson.matrix.MatrixConfiguration;
-import hudson.model.AbstractProject;
 import hudson.model.Job;
 import hudson.model.Node;
 import hudson.model.Queue;
 import hudson.model.queue.CauseOfBlockage;
 import hudson.model.queue.QueueTaskDispatcher;
-import hudson.model.queue.SubTask;
 
 import javax.annotation.CheckForNull;
 import java.util.logging.Logger;
@@ -91,13 +89,13 @@ public class BuildBlockerQueueTaskDispatcher extends QueueTaskDispatcher {
      */
     @Override
     public CauseOfBlockage canRun(Queue.Item item) {
-        if (item.task instanceof AbstractProject) {
+        if (item.task instanceof Job) {
             BuildBlockerProperty property = getBuildBlockerProperty(item);
 
             if (property != null && property.isUseBuildBlocker()) {
-                CauseOfBlockage subTask = checkForBlock(item, property);
-                if (subTask != null) {
-                    return subTask;
+                CauseOfBlockage Job = checkForBlock(item, property);
+                if (Job != null) {
+                    return Job;
                 }
             }
         }
@@ -126,7 +124,7 @@ public class BuildBlockerQueueTaskDispatcher extends QueueTaskDispatcher {
             return null;
         }
 
-        SubTask result = checkAccordingToProperties(node, item, property);
+        Job result = checkAccordingToProperties(node, item, property);
 
 
         if (result != null) {
@@ -139,24 +137,24 @@ public class BuildBlockerQueueTaskDispatcher extends QueueTaskDispatcher {
         return null;
     }
 
-    private SubTask checkAccordingToProperties(Node node, Queue.Item item, BuildBlockerProperty properties) {
+    private Job checkAccordingToProperties(Node node, Queue.Item item, BuildBlockerProperty properties) {
         BlockingJobsMonitor jobsMonitor = monitorFactory.build(properties.getBlockingJobs());
 
         if (checkWasCalledInGlobalContext(node) && properties.getBlockLevel().isGlobal()) {
             LOG.logp(FINE, getClass().getName(), "checkAccordingToProperties", "calling checkAllNodesForRunningBuilds");
-            SubTask checkAllNodesForRunningBuildsResult = jobsMonitor.checkAllNodesForRunningBuilds();
+            Job checkAllNodesForRunningBuildsResult = jobsMonitor.checkAllNodesForRunningBuilds();
             if (foundBlocker(checkAllNodesForRunningBuildsResult)) {
                 return checkAllNodesForRunningBuildsResult;
             }
             if (properties.getScanQueueFor().isAll()) {
                 LOG.logp(FINE, getClass().getName(), "checkAccordingToProperties", "calling checkForQueueEntries");
-                SubTask checkForQueueEntriesResult = jobsMonitor.checkForQueueEntries(item);
+                Job checkForQueueEntriesResult = jobsMonitor.checkForQueueEntries(item);
                 if (foundBlocker(checkForQueueEntriesResult)) {
                     return checkForQueueEntriesResult;
                 }
             } else if (properties.getScanQueueFor().isBuildable()) {
                 LOG.logp(FINE, getClass().getName(), "checkAccordingToProperties", "calling checkForBuildableQueueEntries");
-                SubTask checkForBuildableQueueEntriesResult = jobsMonitor.checkForBuildableQueueEntries(item);
+                Job checkForBuildableQueueEntriesResult = jobsMonitor.checkForBuildableQueueEntries(item);
                 if (foundBlocker(checkForBuildableQueueEntriesResult)) {
                     return checkForBuildableQueueEntriesResult;
                 }
@@ -164,19 +162,19 @@ public class BuildBlockerQueueTaskDispatcher extends QueueTaskDispatcher {
         }
         if (checkWasCalledInNodeContext(node) && properties.getBlockLevel().isNode() && !properties.getBlockLevel().isGlobal()) {
             LOG.logp(FINE, getClass().getName(), "checkAccordingToProperties", "calling checkNodeForRunningBuilds");
-            SubTask checkNodeForRunningBuildsResult = jobsMonitor.checkNodeForRunningBuilds(node);
+            Job checkNodeForRunningBuildsResult = jobsMonitor.checkNodeForRunningBuilds(node);
             if (foundBlocker(checkNodeForRunningBuildsResult)) {
                 return checkNodeForRunningBuildsResult;
             }
             if (properties.getScanQueueFor().isAll()) {
                 LOG.logp(FINE, getClass().getName(), "checkAccordingToProperties", "calling checkNodeForQueueEntries");
-                SubTask checkNodeForQueueEntriesResult = jobsMonitor.checkNodeForQueueEntries(item, node);
+                Job checkNodeForQueueEntriesResult = jobsMonitor.checkNodeForQueueEntries(item, node);
                 if (foundBlocker(checkNodeForQueueEntriesResult)) {
                     return checkNodeForQueueEntriesResult;
                 }
             } else if (properties.getScanQueueFor().isBuildable()) {
                 LOG.logp(FINE, getClass().getName(), "checkAccordingToProperties", "calling checkNodeFOrBuildableQueueEntries");
-                SubTask checkNodeForBuildableQueueEntriesResult = jobsMonitor.checkNodeForBuildableQueueEntries(item, node);
+                Job checkNodeForBuildableQueueEntriesResult = jobsMonitor.checkNodeForBuildableQueueEntries(item, node);
                 if (foundBlocker(checkNodeForBuildableQueueEntriesResult)) {
                     return checkNodeForBuildableQueueEntriesResult;
                 }
@@ -193,7 +191,7 @@ public class BuildBlockerQueueTaskDispatcher extends QueueTaskDispatcher {
         return node == null;
     }
 
-    private boolean foundBlocker(SubTask result) {
+    private boolean foundBlocker(Job result) {
         return result != null;
     }
 

--- a/src/main/java/hudson/plugins/buildblocker/BuildBlockerQueueTaskDispatcher.java
+++ b/src/main/java/hudson/plugins/buildblocker/BuildBlockerQueueTaskDispatcher.java
@@ -24,6 +24,7 @@
 
 package hudson.plugins.buildblocker;
 
+import com.infradna.tool.bridge_method_injector.WithBridgeMethods;
 import hudson.Extension;
 import hudson.matrix.MatrixConfiguration;
 import hudson.model.Job;
@@ -31,6 +32,7 @@ import hudson.model.Node;
 import hudson.model.Queue;
 import hudson.model.queue.CauseOfBlockage;
 import hudson.model.queue.QueueTaskDispatcher;
+import hudson.model.queue.SubTask;
 
 import javax.annotation.CheckForNull;
 import java.util.logging.Logger;
@@ -137,6 +139,7 @@ public class BuildBlockerQueueTaskDispatcher extends QueueTaskDispatcher {
         return null;
     }
 
+    @WithBridgeMethods(value=SubTask.class)
     private Job checkAccordingToProperties(Node node, Queue.Item item, BuildBlockerProperty properties) {
         BlockingJobsMonitor jobsMonitor = monitorFactory.build(properties.getBlockingJobs());
 

--- a/src/main/java/hudson/plugins/buildblocker/BuildBlockerQueueTaskDispatcher.java
+++ b/src/main/java/hudson/plugins/buildblocker/BuildBlockerQueueTaskDispatcher.java
@@ -24,7 +24,6 @@
 
 package hudson.plugins.buildblocker;
 
-import com.infradna.tool.bridge_method_injector.WithBridgeMethods;
 import hudson.Extension;
 import hudson.matrix.MatrixConfiguration;
 import hudson.model.Job;
@@ -32,7 +31,6 @@ import hudson.model.Node;
 import hudson.model.Queue;
 import hudson.model.queue.CauseOfBlockage;
 import hudson.model.queue.QueueTaskDispatcher;
-import hudson.model.queue.SubTask;
 
 import javax.annotation.CheckForNull;
 import java.util.logging.Logger;
@@ -139,7 +137,6 @@ public class BuildBlockerQueueTaskDispatcher extends QueueTaskDispatcher {
         return null;
     }
 
-    @WithBridgeMethods(value=SubTask.class)
     private Job checkAccordingToProperties(Node node, Queue.Item item, BuildBlockerProperty properties) {
         BlockingJobsMonitor jobsMonitor = monitorFactory.build(properties.getBlockingJobs());
 


### PR DESCRIPTION
Any build started with build blocker enabled is impacted if a workflow job is running when triggered and it will not trigger.

Please, do a hard review as even if the tests are passing and I tested the change, I am uncomfortable with the change `SubTask` -> `Job`.

@reviewbybees @jglick