### PR TITLE
better cause of blockage message for jobs in folders

### DIFF
--- a/src/main/java/hudson/plugins/buildblocker/BuildBlockerQueueTaskDispatcher.java
+++ b/src/main/java/hudson/plugins/buildblocker/BuildBlockerQueueTaskDispatcher.java
@@ -132,7 +132,7 @@ public class BuildBlockerQueueTaskDispatcher extends QueueTaskDispatcher {
                 result = ((MatrixConfiguration) result).getParent();
             }
 
-            return CauseOfBlockage.fromMessage(Messages._BlockingJobIsRunning(item.getInQueueForString(), result.getDisplayName()));
+            return CauseOfBlockage.fromMessage(Messages._BlockingJobIsRunning(item.getInQueueForString(), result.getFullDisplayName()));
         }
         return null;
     }


### PR DESCRIPTION
When using the Github Branch Source plugin the job name is just the branch name and is organized in a folder structure named after the Github organization, repository and branch.  

Before this change the cause of blockage message appears as "Blocked for XX sec by master" (or whatever branch is being built), which is not meaningful as it does not inform the user about which job it actually is.  

By using getFullDisplayName() instead of getDisplayName(), the full path to the project is represented in the message resulting in a message like: "Blocked for XX sec by [Org] >> [Repo] >> [Branch]" for the Github Branch Source.  Similarly, folders are represented for jobs that are created in other ways using folders.