### PR TITLE
Fix outdated link to QueueTaskDispatcher extension point

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ plugin](https://wiki.jenkins.io/display/JENKINS/Locks+and+Latches+plugin).
 The main difference is, that it uses regular expressions to find
 potentially blocking jobs by their names in the list of currently
 running builds. It uses the
-[QueueTaskDispatcher](https://wiki.jenkins-ci.org/display/JENKINS/Extension+points#Extensionpoints-hudson.model.queue.QueueTaskDispatcher)
+[QueueTaskDispatcher](https://www.jenkins.io/doc/developer/extensions/jenkins-core/#queuetaskdispatcher)
 to check if the actual job may be build. The dispatcher uses the list of
 regular expressions configured in the job. If one of the currently
 running jobs matches with one of the regular expressions, the job stays


### PR DESCRIPTION
Updated broken link to the QueueTaskDispatcher extension point in the plugin main README.

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
