### PR TITLE
JENKINS-72588 Add build blocker folder property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>cloudbees-folder</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-core</artifactId>
             <scope>test</scope>

--- a/src/main/java/hudson/plugins/buildblocker/BuildBlockerFolderProperty.java
+++ b/src/main/java/hudson/plugins/buildblocker/BuildBlockerFolderProperty.java
@@ -1,0 +1,108 @@
+package hudson.plugins.buildblocker;
+
+import com.cloudbees.hudson.plugins.folder.*;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
+import hudson.Extension;
+import hudson.model.ItemGroup;
+import hudson.model.Job;
+import hudson.util.FormValidation;
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+import org.kohsuke.stapler.QueryParameter;
+
+import static java.util.logging.Level.FINE;
+
+
+/**
+ * Folder property that stores the line feed separated list of
+ * regular expressions that define the blocking jobs.
+ */
+public class BuildBlockerFolderProperty extends AbstractFolderProperty<AbstractFolder<?>> implements IBuildBlockerProperty {
+
+    private boolean useBuildBlocker;
+    private BuildBlockerProperty.BlockLevel blockLevel;
+    private BuildBlockerProperty.QueueScanScope scanQueueFor;
+    private String blockingJobs;
+
+    @DataBoundConstructor
+    public BuildBlockerFolderProperty() {}
+
+    @Override
+    public BuildBlockerProperty.BlockLevel getBlockLevel() {
+        return blockLevel != null ? blockLevel : BuildBlockerProperty.BlockLevel.UNDEFINED;
+    }
+
+    @Override
+    public BuildBlockerProperty.QueueScanScope getScanQueueFor() {
+        return scanQueueFor != null ? scanQueueFor : BuildBlockerProperty.QueueScanScope.DISABLED;
+    }
+
+    @Override
+    public boolean isUseBuildBlocker() {
+        return useBuildBlocker;
+    }
+
+    @Override
+    public String getBlockingJobs() {
+        return blockingJobs;
+    }
+
+    @DataBoundSetter
+    public void setBlockLevel(String blockLevel) {
+        this.blockLevel = BuildBlockerProperty.BlockLevel.from(blockLevel);
+    }
+
+    @DataBoundSetter
+    public void setUseBuildBlocker(boolean useBuildBlocker) {
+        this.useBuildBlocker = useBuildBlocker;
+    }
+
+    @DataBoundSetter
+    public void setScanQueueFor(String scanQueueFor) {
+        this.scanQueueFor = BuildBlockerProperty.QueueScanScope.from(scanQueueFor);;
+    }
+
+    @DataBoundSetter
+    public void setBlockingJobs(String blockingJobs) {
+        this.blockingJobs = blockingJobs;
+    }
+
+    @Extension(optional = true)
+    @Symbol("folderBuildBlocker")
+    public static final class DescriptorImpl extends AbstractFolderPropertyDescriptor {
+
+        @Override
+        public String getDisplayName() {
+            return Messages.DisplayName();
+        }
+
+        /**
+         * Check the regular expression entered by the user
+         */
+        public FormValidation doCheckRegex(@QueryParameter final String blockingJobs) {
+            return BuildBlockerUtils.doCheckRegex(blockingJobs);
+        }
+
+        /**
+         * Return the build blocker folder property for a job by checking all parent
+         * @param job The job
+         * @return The build blocker folder property or null
+         */
+        public @Nullable IBuildBlockerProperty getBuildBlockerFolderProperty(Job<?, ?> job) {
+            ItemGroup<?> itemGroup = job.getParent();
+            while (itemGroup instanceof AbstractFolder<?>) {
+                AbstractFolder<?> folder = (AbstractFolder<?>) itemGroup;
+                BuildBlockerFolderProperty folderProperty = folder.getProperties().get(BuildBlockerFolderProperty.class);
+                if (folderProperty != null) {
+                    return folderProperty;
+                }
+                itemGroup = folder.getParent();
+            }
+            return null;
+        }
+
+    }
+
+}

--- a/src/main/java/hudson/plugins/buildblocker/BuildBlockerProperty.java
+++ b/src/main/java/hudson/plugins/buildblocker/BuildBlockerProperty.java
@@ -46,7 +46,7 @@ import static java.util.logging.Level.FINE;
  * Job property that stores the line feed separated list of
  * regular expressions that define the blocking jobs.
  */
-public class BuildBlockerProperty extends JobProperty<Job<?, ?>> {
+public class BuildBlockerProperty extends JobProperty<Job<?, ?>> implements IBuildBlockerProperty {
 
     private static final Logger LOG = Logger.getLogger(BuildBlockerProperty.class.getName());
 
@@ -55,18 +55,22 @@ public class BuildBlockerProperty extends JobProperty<Job<?, ?>> {
     private QueueScanScope scanQueueFor;
     private String blockingJobs;
 
+    @Override
     public BlockLevel getBlockLevel() {
         return blockLevel != null ? blockLevel : BlockLevel.UNDEFINED;
     }
 
+    @Override
     public QueueScanScope getScanQueueFor() {
         return scanQueueFor != null ? scanQueueFor : QueueScanScope.DISABLED;
     }
 
+    @Override
     public boolean isUseBuildBlocker() {
         return useBuildBlocker;
     }
 
+    @Override
     public String getBlockingJobs() {
         return blockingJobs;
     }
@@ -103,24 +107,7 @@ public class BuildBlockerProperty extends JobProperty<Job<?, ?>> {
          * Check the regular expression entered by the user
          */
         public FormValidation doCheckRegex(@QueryParameter final String blockingJobs) {
-            List<String> listJobs = null;
-            if (StringUtils.isNotBlank(blockingJobs)) {
-                listJobs = Arrays.asList(blockingJobs.split("\n"));
-            }
-            if (listJobs != null) {
-                for (String blockingJob : listJobs) {
-                    try {
-                        Pattern.compile(blockingJob);
-                    } catch (PatternSyntaxException pse) {
-                        return FormValidation.error("Invalid regular expression [" +
-                                blockingJob + "] exception: " +
-                                pse.getDescription());
-                    }
-                }
-                return FormValidation.ok();
-            } else {
-                return FormValidation.ok();
-            }
+            return BuildBlockerUtils.doCheckRegex(blockingJobs);
         }
 
         /**

--- a/src/main/java/hudson/plugins/buildblocker/BuildBlockerUtils.java
+++ b/src/main/java/hudson/plugins/buildblocker/BuildBlockerUtils.java
@@ -1,0 +1,34 @@
+package hudson.plugins.buildblocker;
+
+import hudson.util.FormValidation;
+import org.apache.commons.lang.StringUtils;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+public class BuildBlockerUtils {
+
+    public static FormValidation doCheckRegex(String blockingJobs) {
+        List<String> listJobs = null;
+        if (StringUtils.isNotBlank(blockingJobs)) {
+            listJobs = Arrays.asList(blockingJobs.split("\n"));
+        }
+        if (listJobs != null) {
+            for (String blockingJob : listJobs) {
+                try {
+                    Pattern.compile(blockingJob);
+                } catch (PatternSyntaxException pse) {
+                    return FormValidation.error("Invalid regular expression [" +
+                            blockingJob + "] exception: " +
+                            pse.getDescription());
+                }
+            }
+            return FormValidation.ok();
+        } else {
+            return FormValidation.ok();
+        }
+    }
+
+}

--- a/src/main/java/hudson/plugins/buildblocker/IBuildBlockerProperty.java
+++ b/src/main/java/hudson/plugins/buildblocker/IBuildBlockerProperty.java
@@ -1,0 +1,16 @@
+package hudson.plugins.buildblocker;
+
+/**
+ * Common interface for job and folder properties
+ */
+public interface IBuildBlockerProperty {
+
+    BuildBlockerProperty.BlockLevel getBlockLevel();
+
+    BuildBlockerProperty.QueueScanScope getScanQueueFor();
+
+    boolean isUseBuildBlocker();
+
+    String getBlockingJobs();
+
+}

--- a/src/main/resources/hudson/plugins/buildblocker/BuildBlockerFolderProperty/config.jelly
+++ b/src/main/resources/hudson/plugins/buildblocker/BuildBlockerFolderProperty/config.jelly
@@ -1,0 +1,42 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <f:optionalBlock name="useBuildBlocker" title="${%Block build if certain jobs are running}"
+                     checked="${instance.useBuildBlocker}" inline="true"
+                     help="/plugin/build-blocker-plugin/help-usageBuildBlocker.html">
+        <f:entry title="${%Blocking Jobs}" field="blockingJobs">
+            <f:textarea/>
+        </f:entry>
+        <f:section title="${%configure block level}">
+            <f:entry description="${%blocks this build if any of the defined jobs is running on any node}">
+                <f:radio title="${%block on global level}" name="blockLevel" value="global"
+                         checked="${empty instance.blockLevel or instance.blockLevel.global}"/>
+            </f:entry>
+            <f:entry
+                    description="${%blocks this build if any of the defined jobs is running on the same node this build is running on}">
+                <f:radio title="${%block on node level}" name="blockLevel" value="node"
+                         checked="${instance.blockLevel.node}"/>
+            </f:entry>
+        </f:section>
+        <f:section title="${%configure queue scanning}">
+            <f:entry description="${%consider ready to run builds of the defined jobs for the blocking decision}">
+                <f:radio title="${%check buildable queued builds}" name="scanQueueFor" value="buildable"
+                         checked="${instance.scanQueueFor.buildable}"/>
+            </f:entry>
+            <f:entry
+                    description="${%consider all builds of the defined jobs for the blocking decision, including blocked, waiting, pending and buildable}">
+                <f:radio title="${%check all queued builds}" name="scanQueueFor" value="all"
+                         checked="${instance.scanQueueFor.all}"/>
+            </f:entry>
+            <f:entry>
+                <f:radio title="${%disable queue checking}" name="scanQueueFor" value="disabled"
+                         checked="${empty instance.scanQueueFor or instance.scanQueueFor.disabled}"/>
+            </f:entry>
+        </f:section>
+        <f:entry title="">
+            <div align="right">
+                <f:validateButton title="${%Validate Regex}" progress="${%Checking...}"
+                                  method="checkRegex" with="blockingJobs"/>
+            </div>
+        </f:entry>
+    </f:optionalBlock>
+</j:jelly>

--- a/src/main/resources/hudson/plugins/buildblocker/BuildBlockerFolderProperty/help-blockingJobs.html
+++ b/src/main/resources/hudson/plugins/buildblocker/BuildBlockerFolderProperty/help-blockingJobs.html
@@ -1,0 +1,8 @@
+<div>
+  Insert one regular expression per line to select blocking jobs by their names.
+  E.g.:
+  <pre>
+  .*-deploy
+  ^maintainance.*
+  </pre>
+</div>


### PR DESCRIPTION
Fixes JENKINS-72588 https://issues.jenkins.io/browse/JENKINS-72588

Add possibility to create the build blocker property per folder (or multibranch pipeline).

Meaning all jobs inside a folder (or all branches inside a multi branch will inherit from the property)

### Testing done

Automated tests
Run some sanity test with hpi:run by creating a folder an adding pipelines to it.
Ensure jobs are blocked 


```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
