### PR TITLE
[JENKINS-73119] Make folders dependency required, not optional

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,6 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>cloudbees-folder</artifactId>
-            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.81</version>
+        <version>4.82</version>
         <relativePath />
     </parent>
 


### PR DESCRIPTION
## [JENKINS-73119] Make folders dependency required, not optional

If the folders plugin is not installed, jobs fail to start and report: "Exception evaluating if the gueue can run the task"

Once the folders plugin is declared as a required dependency rather than an optional dependency, then the folders plugin will be installed when the plugin is updated and jobs will run successfully.

Confirmed the failure by running Jenkins 2.426.3 with the build blocker plugin 165.v5ecb_fb_f61520 installed.  I created a freestyle job and ran it.  The run failed with the message "Exception evaluating if the gueue can run the task".

Confirmed the failure is resolved by installing the folders plugin 6.858.v898218f3609d.  That is the version offered by the plugin bill of materials version that is defined in this pom file.

Also updates the parent pom to 4.82 so that we're using the most recent parent pom.

### Testing done

Confirmed that automated tests pass.

Once an incremental build is available, will confirm that plugin installation manager correctly installs folders plugin when requested to install the incremental build.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
