### PR TITLE
[JENKINS-73119] Catch the class not found exception

### DIFF
--- a/src/main/java/hudson/plugins/buildblocker/BuildBlockerQueueTaskDispatcher.java
+++ b/src/main/java/hudson/plugins/buildblocker/BuildBlockerQueueTaskDispatcher.java
@@ -223,7 +223,7 @@ public class BuildBlockerQueueTaskDispatcher extends QueueTaskDispatcher {
                 return property;
             }
         }
-        catch (Exception e) {
+        catch (NoClassDefFoundError | Exception e) {
             LOG.logp(FINE, getClass().getName(), "getBuildBlockerProperty", "Unable to check parent for build blocker property. Make sure cloudbees-folder plugin is installed.", e);
         }
 


### PR DESCRIPTION
## [JENKINS-73119](https://issues.jenkins.io/browse/JENKINS-73119) Catch the class not found exception

If the folders plugin is not installed, jobs fail to start and report: "Exception evaluating if the gueue can run the task"

Once the class not found exception is caught, then the job runs as expected.

Users that need the fix before a release is available can download it from [Artifactory](https://repo.jenkins-ci.org/artifactory/incrementals/org/jenkins-ci/plugins/build-blocker-plugin/166.v7992612cb_4b_5/build-blocker-plugin-166.v7992612cb_4b_5.hpi) and install it on their controller.  If plugin installation manager tool is being used, then the syntax to use the pull request build is:

```
build-blocker-plugin:incrementals;org.jenkins-ci.plugins;166.v7992612cb_4b_5
```

### Testing done

Confirmed the failure by running Jenkins 2.426.3 with the build blocker plugin 165.v5ecb_fb_f61520 installed.  I created a freestyle job and ran it.  The run failed with the message "Exception evaluating if the gueue can run the task".

Confirmed the failure is resolved by installing the build of this commit and ran the same job without error.  Confirmed that the class not found exception was written to the Jenkins logger when I enabled FINE logging for the BuildBlockerQueueTaskDispatcher.  FINE logging is disabled by default, so the Jenkins log will not be cluttered by those exception messages unless an administrator specifically enables it.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
